### PR TITLE
fix: connect should use peer id in bytes

### DIFF
--- a/src/daemon.js
+++ b/src/daemon.js
@@ -50,7 +50,7 @@ class Daemon {
     const peer = connectRequest.connect.peer
     const addrs = connectRequest.connect.addrs
     const peerInfo = new PeerInfo(
-      PeerId.createFromB58String(peer)
+      PeerId.createFromBytes(peer)
     )
     addrs.forEach((a) => {
       peerInfo.multiaddrs.add(multiaddr(a))

--- a/test/daemon.spec.js
+++ b/test/daemon.spec.js
@@ -79,7 +79,7 @@ describe('daemon', () => {
     const request = {
       type: Request.Type.CONNECT,
       connect: {
-        peer: Buffer.from(libp2pPeer.peerInfo.id.toB58String()),
+        peer: Buffer.from(libp2pPeer.peerInfo.id.toBytes()),
         addrs: libp2pPeer.peerInfo.multiaddrs.toArray().map(addr => addr.buffer)
       },
       streamOpen: null,


### PR DESCRIPTION
According to the spec and the go implementation of the daemon [libp2p/go-libp2p-daemon/conn.go#L177](https://github.com/libp2p/go-libp2p-daemon/blob/1d7d0a25b6152441e4e8a216d53ee2f7240a161e/conn.go#L177), connect should receive the peerId in bytes and not in b58str