### PR TITLE
fix: remove ipfs from identify multiaddrs

### DIFF
--- a/src/daemon.js
+++ b/src/daemon.js
@@ -366,7 +366,9 @@ class Daemon {
           enc.write(OkResponse({
             identify: {
               id: this.libp2p.peerInfo.id.toBytes(),
-              addrs: this.libp2p.peerInfo.multiaddrs.toArray().map(m => m.buffer)
+              // temporary removal of "/ipfs/..." from multiaddrs
+              // this will be solved in: https://github.com/libp2p/js-libp2p/issues/323
+              addrs: this.libp2p.peerInfo.multiaddrs.toArray().map(m => m.decapsulate('ipfs').buffer)
             }
           }))
           break

--- a/test/daemon.spec.js
+++ b/test/daemon.spec.js
@@ -143,9 +143,10 @@ describe('daemon', () => {
 
     const response = Response.decode(await stream.first())
     expect(response.type).to.eql(Response.Type.OK)
+
     expect(response.identify).to.eql({
       id: daemon.libp2p.peerInfo.id.toBytes(),
-      addrs: daemon.libp2p.peerInfo.multiaddrs.toArray().map(m => m.buffer)
+      addrs: daemon.libp2p.peerInfo.multiaddrs.toArray().map(m => m.decapsulate('ipfs').buffer)
     })
     stream.end()
   })


### PR DESCRIPTION
While `js-libp2p` does not handle this on [libp2p/js-libp2p#323](https://github.com/libp2p/js-libp2p/issues/323), this PR removes the  `/ipfs/{peer_id}` from the multiaddress