### PR TITLE
fix: decapsulate ipfs from dht find peer

### DIFF
--- a/src/daemon.js
+++ b/src/daemon.js
@@ -369,17 +369,7 @@ class Daemon {
           enc.write(OkResponse({
             identify: {
               id: this.libp2p.peerInfo.id.toBytes(),
-              // temporary removal of "/ipfs/..." from multiaddrs
-              // this will be solved in: https://github.com/libp2p/js-libp2p/issues/323
-              addrs: this.libp2p.peerInfo.multiaddrs.toArray().map(m => {
-                let buffer
-                try {
-                  buffer = m.decapsulate('ipfs').buffer
-                } catch (_) {
-                  buffer = m.buffer
-                }
-                return buffer
-              })
+              addrs: this.libp2p.peerInfo.multiaddrs.toArray().map(m => m.buffer)
             }
           }))
           break

--- a/src/libp2p.js
+++ b/src/libp2p.js
@@ -240,6 +240,20 @@ class DaemonLibp2p extends Libp2p {
             this.peerInfo.multiaddrs.add(addr)
           })
         }
+
+        // temporary removal of "/ipfs/..." from multiaddrs
+        // this will be solved in: https://github.com/libp2p/js-libp2p/issues/323
+        this.peerInfo.multiaddrs.toArray().forEach(m => {
+          let ma
+          try {
+            ma = m.decapsulate('ipfs')
+          } catch (_) {
+            ma = m
+          }
+
+          this.peerInfo.multiaddrs.replace(m, ma)
+        })
+
         resolve()
       })
     })

--- a/test/daemon/core.spec.js
+++ b/test/daemon/core.spec.js
@@ -143,7 +143,7 @@ describe('core features', () => {
 
     expect(response.identify).to.eql({
       id: daemon.libp2p.peerInfo.id.toBytes(),
-      addrs: daemon.libp2p.peerInfo.multiaddrs.toArray().map(m => m.decapsulate('ipfs').buffer)
+      addrs: daemon.libp2p.peerInfo.multiaddrs.toArray().map(m => m.buffer)
     })
     stream.end()
   })


### PR DESCRIPTION
While `js-libp2p` does not handle this on [libp2p/js-libp2p#323](https://github.com/libp2p/js-libp2p/issues/323), this PR removes the  `/ipfs/{peer_id}` from the multiaddress