### PR TITLE
feat: add support initial peerstore support

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "cids": "~0.5.7",
     "debug": "^4.1.1",
     "length-prefixed-stream": "github:jacobheun/length-prefixed-stream#v2.0.0-rc.1",
-    "libp2p": "~0.24.4",
+    "libp2p": "~0.25.0-rc.5",
     "libp2p-bootstrap": "~0.9.7",
     "libp2p-kad-dht": "~0.14.3",
     "libp2p-mplex": "~0.8.4",

--- a/src/daemon.js
+++ b/src/daemon.js
@@ -13,6 +13,7 @@ const { multiaddrToNetConfig } = require('./util')
 const {
   Request,
   DHTRequest,
+  PeerstoreRequest,
   PSRequest,
   Response,
   DHTResponse,
@@ -213,6 +214,33 @@ class Daemon {
         resolve()
       })
     })
+  }
+
+  async handlePeerstoreRequest ({ peerStore }, enc) {
+    switch (peerStore.type) {
+      case PeerstoreRequest.Type.GET_PROTOCOLS: {
+        let protos
+        try {
+          const peerId = PeerId.createFromBytes(peerStore.id)
+          const peerInfo = this.libp2p.peerBook.get(peerId)
+          protos = Array.from(peerInfo.protocols)
+        } catch (err) {
+          throw new Error('ERR_INVALID_PEERSTORE_REQUEST')
+        }
+
+        await new Promise((resolve) => {
+          enc.write(
+            OkResponse({
+              peerStore: { protos }
+            }),
+            resolve)
+        })
+        break
+      }
+      default: {
+        throw new Error('ERR_INVALID_REQUEST_TYPE')
+      }
+    }
   }
 
   /**
@@ -484,6 +512,15 @@ class Daemon {
 
           // write the response
           enc.write(OkResponse())
+          break
+        }
+        case Request.Type.PEERSTORE: {
+          try {
+            await this.handlePeerstoreRequest(request, enc)
+          } catch (err) {
+            enc.write(ErrorResponse(err.message))
+            break
+          }
           break
         }
         case Request.Type.PUBSUB: {

--- a/src/daemon.js
+++ b/src/daemon.js
@@ -237,6 +237,9 @@ class Daemon {
         })
         break
       }
+      case PeerstoreRequest.Type.GET_PEER_INFO: {
+        throw new Error('ERR_NOT_IMPLEMENTED')
+      }
       default: {
         throw new Error('ERR_INVALID_REQUEST_TYPE')
       }

--- a/src/libp2p.js
+++ b/src/libp2p.js
@@ -451,10 +451,10 @@ const createLibp2p = async ({
         }
       },
       dht: {
+        enabled: dht,
         kBucketSize: 20
       },
       EXPERIMENTAL: {
-        dht: dht,
         pubsub: pubsub
       }
     }

--- a/src/protocol/index.js
+++ b/src/protocol/index.js
@@ -162,9 +162,8 @@ message PSResponse {
 
 message PeerstoreRequest {
   enum Type {
-    ADD_PROTOCOLS = 1;
-    GET_PROTOCOLS = 2;
-    GET_PEER_INFO = 3;
+    GET_PROTOCOLS = 1;
+    GET_PEER_INFO = 2;
   }
 
   required Type type = 1;

--- a/src/protocol/index.js
+++ b/src/protocol/index.js
@@ -13,6 +13,7 @@ message Request {
     CONNMANAGER    = 6;
     DISCONNECT     = 7;
     PUBSUB         = 8;
+    PEERSTORE      = 9;
   }
 
   required Type type = 1;
@@ -24,6 +25,7 @@ message Request {
   optional ConnManagerRequest connManager = 6;
   optional DisconnectRequest disconnect = 7;
   optional PSRequest pubsub = 8;
+  optional PeerstoreRequest peerStore = 9;
 }
 
 message Response {
@@ -39,6 +41,7 @@ message Response {
   optional DHTResponse dht = 5;
   repeated PeerInfo peers = 6;
   optional PSResponse pubsub = 7;
+  optional PeerstoreResponse peerStore = 8;
 }
 
 message IdentifyResponse {
@@ -49,11 +52,13 @@ message IdentifyResponse {
 message ConnectRequest {
   required bytes peer = 1;
   repeated bytes addrs = 2;
+  optional int64 timeout = 3;
 }
 
 message StreamOpenRequest {
   required bytes peer = 1;
   repeated string proto = 2;
+  optional int64 timeout = 3;
 }
 
 message StreamHandlerRequest {
@@ -87,7 +92,7 @@ message DHTRequest {
   required Type type = 1;
   optional bytes peer = 2;
   optional bytes cid = 3;
-  optional string key = 4;
+  optional bytes key = 4;
   optional bytes value = 5;
   optional int32 count = 6;
   optional int64 timeout = 7;
@@ -112,9 +117,9 @@ message PeerInfo {
 
 message ConnManagerRequest {
   enum Type {
-    TAG_PEER   = 0;
-    UNTAG_PEER = 1;
-    TRIM       = 2;
+    TAG_PEER        = 0;
+    UNTAG_PEER      = 1;
+    TRIM            = 2;
   }
 
   required Type type = 1;
@@ -153,5 +158,22 @@ message PSMessage {
 message PSResponse {
   repeated string topics = 1;
   repeated bytes peerIDs = 2;
+}
+
+message PeerstoreRequest {
+  enum Type {
+    ADD_PROTOCOLS = 1;
+    GET_PROTOCOLS = 2;
+    GET_PEER_INFO = 3;
+  }
+
+  required Type type = 1;
+  optional bytes id = 2;
+  repeated string protos = 3;
+}
+
+message PeerstoreResponse {
+  optional PeerInfo peer = 1;
+  repeated string protos = 2;
 }
 `)

--- a/test/daemon/peerstore.spec.js
+++ b/test/daemon/peerstore.spec.js
@@ -104,4 +104,25 @@ describe('peerstore features', () => {
     })
     stream.end()
   })
+
+  it('NOT IMPLEMENTED get peer info', async () => {
+    client = new Client(daemonAddr)
+
+    await client.attach()
+
+    const request = {
+      type: Request.Type.PEERSTORE,
+      peerStore: {
+        type: PeerstoreRequest.Type.GET_PEER_INFO,
+        id: Buffer.from(libp2pPeer.peerInfo.id.toBytes())
+      }
+    }
+
+    const stream = client.send(request)
+
+    const message = await stream.first()
+    let response = Response.decode(message)
+    expect(response.type).to.eql(Response.Type.ERROR)
+    expect(response.error.msg).to.eql('ERR_NOT_IMPLEMENTED')
+  })
 })

--- a/test/daemon/peerstore.spec.js
+++ b/test/daemon/peerstore.spec.js
@@ -1,0 +1,107 @@
+/* eslint-env mocha */
+/* eslint max-nested-callbacks: ['error', 5] */
+'use strict'
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+const expect = chai.expect
+const os = require('os')
+const path = require('path')
+const ma = require('multiaddr')
+const { createDaemon } = require('../../src/daemon')
+const Client = require('../../src/client')
+const { createLibp2p } = require('../../src/libp2p')
+const { isWindows } = require('../../src/util')
+const { connect } = require('../util')
+const {
+  Request,
+  Response,
+  PeerstoreRequest
+} = require('../../src/protocol')
+
+const daemonAddr = isWindows
+  ? ma('/ip4/0.0.0.0/tcp/8080')
+  : ma(`/unix${path.resolve(os.tmpdir(), '/tmp/p2pd.sock')}`)
+
+describe('peerstore features', () => {
+  let daemon
+  let libp2pPeer
+  let client
+
+  before(async function () {
+    // this.timeout(20e3)
+    daemon = await createDaemon({
+      quiet: false,
+      q: false,
+      bootstrap: false,
+      hostAddrs: '/ip4/0.0.0.0/tcp/0,/ip4/0.0.0.0/tcp/0/ws',
+      b: false,
+      dht: true,
+      dhtClient: false,
+      connMgr: false,
+      listen: daemonAddr.toString(),
+      id: '',
+      bootstrapPeers: ''
+    })
+    libp2pPeer = await createLibp2p({
+      dht: true,
+      hostAddrs: '/ip4/0.0.0.0/tcp/0'
+    })
+
+    await Promise.all([
+      daemon.start(),
+      libp2pPeer.start()
+    ])
+
+    await connect({
+      libp2pPeer,
+      multiaddr: daemonAddr
+    })
+  })
+
+  before(async () => {
+    await new Promise(resolve => setTimeout(resolve, 1e3))
+  })
+
+  after(() => {
+    return Promise.all([
+      daemon.stop(),
+      libp2pPeer.stop()
+    ])
+  })
+
+  afterEach(async () => {
+    await client && client.close()
+  })
+
+  it('should be able to get the protocols for a peer', async () => {
+    client = new Client(daemonAddr)
+
+    await client.attach()
+
+    const request = {
+      type: Request.Type.PEERSTORE,
+      peerStore: {
+        type: PeerstoreRequest.Type.GET_PROTOCOLS,
+        id: Buffer.from(libp2pPeer.peerInfo.id.toBytes())
+      }
+    }
+
+    const stream = client.send(request)
+
+    const message = await stream.first()
+    let response = Response.decode(message)
+    expect(response.type).to.eql(Response.Type.OK)
+    expect(response.peerStore).to.eql({
+      protos: [
+        '/mplex/6.7.0',
+        '/ipfs/id/1.0.0',
+        '/ipfs/ping/1.0.0',
+        '/libp2p/circuit/relay/0.1.0',
+        '/ipfs/kad/1.0.0'
+      ],
+      peer: null
+    })
+    stream.end()
+  })
+})

--- a/test/protocol.spec.js
+++ b/test/protocol.spec.js
@@ -20,7 +20,8 @@ describe('protocol', () => {
         peer: Buffer.from('QmTarget'),
         addrs: [
           multiaddr('/ip4/0.0.0.0/tcp/0').buffer
-        ]
+        ],
+        timeout: 0
       }
       const request = {
         type: Request.Type.CONNECT,
@@ -29,6 +30,7 @@ describe('protocol', () => {
         streamHandler: null,
         dht: null,
         disconnect: null,
+        peerStore: null,
         pubsub: null,
         connManager: null
       }
@@ -40,7 +42,8 @@ describe('protocol', () => {
     it('should be able to encode/decode a StreamOpenRequest', () => {
       const streamOpenRequest = {
         peer: Buffer.from('QmTarget'),
-        proto: ['/p2pdaemon/1.0.0']
+        proto: ['/p2pdaemon/1.0.0'],
+        timeout: 0
       }
       const request = {
         type: Request.Type.STREAM_OPEN,
@@ -49,6 +52,7 @@ describe('protocol', () => {
         streamHandler: null,
         dht: null,
         disconnect: null,
+        peerStore: null,
         pubsub: null,
         connManager: null
       }
@@ -69,6 +73,7 @@ describe('protocol', () => {
         streamHandler: streamHandlerRequest,
         dht: null,
         disconnect: null,
+        peerStore: null,
         pubsub: null,
         connManager: null
       }
@@ -82,7 +87,7 @@ describe('protocol', () => {
         type: DHTRequest.Type.FIND_PEER,
         peer: Buffer.from('QmTarget'),
         cid: null,
-        key: '',
+        key: Buffer.alloc(0),
         value: null,
         count: 0,
         timeout: 0
@@ -94,6 +99,7 @@ describe('protocol', () => {
         streamHandler: null,
         dht: dhtRequest,
         disconnect: null,
+        peerStore: null,
         pubsub: null,
         connManager: null
       }
@@ -116,6 +122,7 @@ describe('protocol', () => {
         streamHandler: null,
         dht: null,
         disconnect: null,
+        peerStore: null,
         pubsub: null,
         connManager: connManagerRequest
       }
@@ -136,6 +143,7 @@ describe('protocol', () => {
         identify: null,
         dht: null,
         pubsub: null,
+        peerStore: null,
         peers: []
       }
       const message = Response.encode(response)


### PR DESCRIPTION
This also bumps to the latest release candidate for js-libp2p

Note: the spec for this is still underway and may be subject to change, https://github.com/libp2p/go-libp2p-daemon/pull/91. This is to unblock interop testing with identify in support of the gossipsub needs for peer protocol knowledge.

- [x] Requires https://github.com/libp2p/js-libp2p-switch/pull/313