### PR TITLE
fix: peer info

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "cids": "~0.6.0",
     "debug": "^4.1.1",
     "length-prefixed-stream": "github:jacobheun/length-prefixed-stream#v2.0.0-rc.1",
-    "libp2p": "~0.25.0-rc.5",
+    "libp2p": "~0.25.2",
     "libp2p-bootstrap": "~0.9.7",
     "libp2p-kad-dht": "~0.14.12",
     "libp2p-mplex": "~0.8.5",

--- a/src/libp2p.js
+++ b/src/libp2p.js
@@ -342,11 +342,15 @@ class DaemonLibp2p extends Libp2p {
         if (err) return reject(err)
         if (!conn) return resolve()
 
-        // Convert the pull stream to an iterable node stream
-        const connection = pullToStream(conn)
-        connection.peerInfo = conn.peerInfo
+        conn.getPeerInfo((err, peerInfo) => {
+          if (err) return reject(err)
 
-        resolve(connection)
+          // Convert the pull stream to an iterable node stream
+          const connection = pullToStream(conn)
+          connection.peerInfo = peerInfo
+
+          resolve(connection)
+        })
       })
     })
   }


### PR DESCRIPTION
The daemon was pulling `peerInfo` shallowly from the connection instead of calling `getPeerInfo`, which ensures recursive retrieval. 