### PR TITLE
Fix secp256k1 test

### DIFF
--- a/test/daemon/config.spec.js
+++ b/test/daemon/config.spec.js
@@ -83,6 +83,6 @@ describe('configuration', () => {
     await daemon.start()
 
     const peerId = daemon.libp2p.peerInfo.id
-    expect(peerId.toB58String()).to.eql('QmaXywut5mxJHYGE2qGht9e6BynFNKrWUwqMgJ6MVE9Q2J')
+    expect(peerId.toB58String()).to.eql('16Uiu2HAm7txvwZbeK5g3oB3DrRhnARTEjTNorVreWJomfHJHbEu2')
   })
 })


### PR DESCRIPTION
Fix test for loading Secp256k1 private key, to expect the peer ID to be computed with identity hash, as this is the new behaviour in the peer-id package.