### PR TITLE
test: bump timeout for peerstore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ stages:
 
 node_js:
   - '10'
+  - '12'
 
 os:
   - linux

--- a/package.json
+++ b/package.json
@@ -37,13 +37,13 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "aegir": "^19.0.5",
+    "aegir": "^20.0.0",
     "chai": "^4.2.0",
     "chai-bytes": "~0.1.2",
     "dirty-chai": "^2.0.1",
     "mocha": "^6.1.2",
     "multihashes": "~0.4.14",
-    "sinon": "^7.3.1"
+    "sinon": "^7.4.1"
   },
   "dependencies": {
     "cids": "~0.6.0",

--- a/src/cli/bin.js
+++ b/src/cli/bin.js
@@ -96,22 +96,18 @@ const main = async (processArgs) => {
       yargs.showHelp()
     })
 
-  try {
-    const { data, argv } = await parser.parse(processArgs)
-    if (data) {
-      // Log help and exit
-      // eslint-disable-next-line
-      log(data)
-      process.exit(0)
-    }
-    const daemon = await Daemon.createDaemon(argv)
-    await daemon.start()
-    if (!argv.quiet) {
-      // eslint-disable-next-line
-      log('daemon has started')
-    }
-  } catch (err) {
-    throw err
+  const { data, argv } = await parser.parse(processArgs)
+  if (data) {
+    // Log help and exit
+    // eslint-disable-next-line
+    log(data)
+    process.exit(0)
+  }
+  const daemon = await Daemon.createDaemon(argv)
+  await daemon.start()
+  if (!argv.quiet) {
+    // eslint-disable-next-line
+    log('daemon has started')
   }
 }
 

--- a/src/daemon.js
+++ b/src/daemon.js
@@ -319,7 +319,7 @@ class Daemon {
     switch (dht.type) {
       case DHTRequest.Type.FIND_PEER: {
         const peerId = PeerId.createFromBytes(dht.peer)
-        let peer = await this.libp2p.peerRouting.findPeer(peerId)
+        const peer = await this.libp2p.peerRouting.findPeer(peerId)
 
         return [OkResponse({
           dht: {
@@ -337,7 +337,7 @@ class Daemon {
         // Currently the dht doesn't provide a streaming interface.
         // So we need to collect all of the responses and then compose
         // the response 'stream' to the client
-        let responses = [OkResponse({
+        const responses = [OkResponse({
           dht: {
             type: DHTResponse.Type.BEGIN
           }
@@ -373,7 +373,7 @@ class Daemon {
           Buffer.from(dht.key)
         )
 
-        let responses = [OkResponse({
+        const responses = [OkResponse({
           dht: {
             type: DHTResponse.Type.BEGIN
           }

--- a/src/libp2p.js
+++ b/src/libp2p.js
@@ -204,21 +204,27 @@ class DaemonLibp2p extends Libp2p {
     this.announceAddrs = announceAddrs
     this.needsPullStream = libp2pOpts.config.pubsub.enabled
   }
+
   get contentRouting () {
     return this._contentRouting
   }
+
   set contentRouting (routing) {
     this._contentRouting = new ContentRouting(routing)
   }
+
   get peerRouting () {
     return this._peerRouting
   }
+
   set peerRouting (routing) {
     this._peerRouting = new PeerRouting(routing)
   }
+
   get dht () {
     return this._kadDHT
   }
+
   set dht (_) {
     this._kadDHT = new DHT(this)
   }
@@ -295,7 +301,7 @@ class DaemonLibp2p extends Libp2p {
         handler(protocol, conn)
       } else {
         conn.getPeerInfo((_, peerInfo) => {
-          let connection = pullToStream(conn)
+          const connection = pullToStream(conn)
           connection.peerInfo = peerInfo
           handler(protocol, connection)
         })

--- a/test/cli.spec.js
+++ b/test/cli.spec.js
@@ -7,7 +7,7 @@ const sinon = require('sinon')
 const cli = require('../src/cli/bin')
 
 describe('cli', () => {
-  let daemon = require('../src/daemon')
+  const daemon = require('../src/daemon')
 
   afterEach(() => {
     sinon.restore()

--- a/test/daemon/config.spec.js
+++ b/test/daemon/config.spec.js
@@ -15,7 +15,9 @@ const daemonAddr = isWindows
   ? ma('/ip4/0.0.0.0/tcp/8080')
   : ma(`/unix${path.resolve(os.tmpdir(), '/tmp/p2pd.sock')}`)
 
-describe('configuration', () => {
+describe('configuration', function () {
+  this.timeout(10e3)
+
   let daemon
   afterEach(async () => {
     await daemon && daemon.stop()

--- a/test/daemon/core.spec.js
+++ b/test/daemon/core.spec.js
@@ -90,7 +90,7 @@ describe('core features', () => {
     const stream = client.send(request)
 
     const message = await stream.first()
-    let response = Response.decode(message)
+    const response = Response.decode(message)
     expect(response.type).to.eql(Response.Type.OK)
     stream.end()
   })

--- a/test/daemon/peerstore.spec.js
+++ b/test/daemon/peerstore.spec.js
@@ -29,7 +29,7 @@ describe('peerstore features', () => {
   let client
 
   before(async function () {
-    // this.timeout(20e3)
+    this.timeout(20e3)
     daemon = await createDaemon({
       quiet: false,
       q: false,

--- a/test/daemon/peerstore.spec.js
+++ b/test/daemon/peerstore.spec.js
@@ -90,7 +90,7 @@ describe('peerstore features', () => {
     const stream = client.send(request)
 
     const message = await stream.first()
-    let response = Response.decode(message)
+    const response = Response.decode(message)
     expect(response.type).to.eql(Response.Type.OK)
     expect(response.peerStore).to.eql({
       protos: [
@@ -121,7 +121,7 @@ describe('peerstore features', () => {
     const stream = client.send(request)
 
     const message = await stream.first()
-    let response = Response.decode(message)
+    const response = Response.decode(message)
     expect(response.type).to.eql(Response.Type.ERROR)
     expect(response.error.msg).to.eql('ERR_NOT_IMPLEMENTED')
   })

--- a/test/daemon/pubsub.spec.js
+++ b/test/daemon/pubsub.spec.js
@@ -168,6 +168,7 @@ const testPubsub = (router) => {
       const topic = 'test-topic'
       const data = Buffer.from('test-data')
 
+      // eslint-disable-next-line no-async-promise-executor
       return new Promise(async (resolve, reject) => {
         client = new Client(daemonAddr)
 
@@ -190,7 +191,7 @@ const testPubsub = (router) => {
 
         let stream = client.send(request)
 
-        let message = await stream.first()
+        const message = await stream.first()
         let response = Response.decode(message)
         expect(response.type).to.eql(Response.Type.OK)
         stream.end()
@@ -234,6 +235,7 @@ const testPubsub = (router) => {
       const topic = 'test-topic'
       const data = Buffer.from('test-data')
 
+      // eslint-disable-next-line no-async-promise-executor
       return new Promise(async (resolve) => {
         client = new Client(daemonAddr)
 
@@ -250,7 +252,7 @@ const testPubsub = (router) => {
 
         let stream = client.send(request)
 
-        let message = await stream.first()
+        const message = await stream.first()
         let response = Response.decode(message)
         expect(response.type).to.eql(Response.Type.OK)
         stream.end()

--- a/test/daemon/streams.spec.js
+++ b/test/daemon/streams.spec.js
@@ -137,7 +137,7 @@ describe('streams', function () {
 
       // Read the stream info from the daemon, then pipe to echo
       const message = await ends(dec).first()
-      let response = StreamInfo.decode(message)
+      const response = StreamInfo.decode(message)
 
       expect(response.peer).to.eql(libp2pPeer.peerInfo.id.toBytes())
       expect(response.proto).to.eql('/echo/1.0.0')

--- a/test/util/index.js
+++ b/test/util/index.js
@@ -36,7 +36,7 @@ async function connect ({
   const stream = client.send(request)
 
   const message = await stream.first()
-  let response = Response.decode(message)
+  const response = Response.decode(message)
   expect(response.type).to.eql(Response.Type.OK)
   stream.end()
 


### PR DESCRIPTION
Peer store tests had the standard timeout which can cause flakey failures. This bumps the time for node generation.

- Adds node 12 to travis builds
- Updates aegir and fixes linting