### PR TITLE
feat: specify libp2p dependency through env

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ For a full list of options, you can run help `jsp2pd --help`.
 Running the defaults, `jsp2pd`, will start the daemon and bind it to a local unix socket path.
 Daemon clients will be able to communicate with the daemon over that unix socket.
 
+As an alternative, you can use this daemon with a different version of libp2p as the one specified in `package.json`. You just need to define its path through an environment variable as follows:
+
+```sh
+export LIBP2P_JS=./../../js-libp2p/src/index.js
+```
+
 ## Contribute
 
 This module is actively under development. Please check out the issues and submit PRs!

--- a/src/libp2p.js
+++ b/src/libp2p.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const Libp2p = require('libp2p')
+const Libp2p = process.env.LIBP2P_JS ? require(process.env.LIBP2P_JS) : require('libp2p')
 const TCP = require('libp2p-tcp')
 const WS = require('libp2p-websockets')
 const Bootstrap = require('libp2p-bootstrap')


### PR DESCRIPTION
Added support for specifying the libp2p implementation we want to use in the daemon through an environment variable. This was based on what `ipfsd-ctl` is currently doing.

This allows us to run the interop tests through `js-libp2p` CI.