### PR TITLE
feat: add introspection

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
     "sinon": "^9.0.0"
   },
   "dependencies": {
+    "@libp2p/observer-data": "^1.1.0",
+    "@libp2p/observer-proto": "^1.1.0",
+    "base32.js": "^0.1.0",
     "cids": "^1.1.5",
     "debug": "^4.3.1",
     "it-buffer": "^0.1.2",
@@ -60,7 +63,7 @@
     "libp2p-bootstrap": "^0.12.1",
     "libp2p-floodsub": "^0.24.1",
     "libp2p-gossipsub": "^0.8.0",
-    "libp2p-kad-dht": "^0.20.6",
+    "libp2p-kad-dht": "libp2p/js-libp2p-kad-dht#feat/peer-eviction",
     "libp2p-mplex": "^0.10.0",
     "libp2p-noise": "^2.0.0",
     "libp2p-secio": "^0.13.1",

--- a/src/cli/bin.js
+++ b/src/cli/bin.js
@@ -42,12 +42,12 @@ const main = async (processArgs) => {
     .option('secio', {
       desc: 'Enables secio connection encryption',
       type: 'boolean',
-      default: true
+      default: false
     })
     .option('noise', {
       desc: 'Enables noise connection encryption',
       type: 'boolean',
-      default: false
+      default: true
     })
     .option('bootstrap', {
       alias: 'b',
@@ -63,7 +63,7 @@ const main = async (processArgs) => {
     .option('dht', {
       desc: 'Enables the DHT in full node mode',
       type: 'boolean',
-      default: false
+      default: true
     })
     .option('dhtClient', {
       desc: '(Not yet supported) Enables the DHT in client mode',
@@ -118,6 +118,10 @@ const main = async (processArgs) => {
   if (!argv.quiet) {
     // eslint-disable-next-line
     log('daemon has started')
+    log('daemon is listening on:')
+    daemon.libp2p.multiaddrs.forEach((ma) => {
+      log(`${ma}/p2p/${daemon.libp2p.peerId.toB58String()}`)
+    })
   }
 }
 

--- a/src/introspection/create-message.js
+++ b/src/introspection/create-message.js
@@ -1,0 +1,71 @@
+'use strict'
+
+const {
+  createResponseServerMessage,
+  createRuntimeServerMessage,
+  createStateServerMessage
+} = require('./messages/server-message')
+
+const {
+  createConnection
+} = require('./messages/connections')
+
+const {
+  createState: createStateMessage
+} = require('./messages/states')
+
+const {
+  createDHT,
+  updateDHT,
+} = require('./messages/dht')
+
+const {
+  createCommandMessage
+} = require('./messages/command-response')
+
+const {
+  createBufferSegment
+} = require('./utils')
+
+// TODO: Perhaps use in this context
+function createVersion () {
+  const versionBuf = Buffer.alloc(4)
+  versionBuf.writeUInt32LE(1, 0)
+  return versionBuf
+}
+
+function createRuntimeMessage (options = {}, runtime = createRuntime(options)) {
+  const runtimePacket = createRuntimeServerMessage(runtime)
+  return createBufferSegment(runtimePacket)
+}
+
+function createCommandResponse (options = {}, response = createCommandMessage(options)) {
+  const responsePacket = createResponseServerMessage(response)
+  return createBufferSegment(responsePacket)
+}
+
+function createConnections (connections = []) {
+  const connectionsPbs = []
+
+  connections.forEach((c) => {
+    connectionsPbs.push(createConnection(c))
+  })
+
+  return connectionsPbs
+}
+
+function createState (connections, utcNow, dht, durationSnapshot) {
+  const state = createStateMessage(connections, utcNow, dht, durationSnapshot)
+  const statePacket = createStateServerMessage(state)
+  return createBufferSegment(statePacket)
+}
+
+module.exports = {
+  createDHT,
+  createConnections,
+  createRuntimeMessage,
+  createVersion,
+  createState,
+  createCommandResponse,
+  updateDHT
+}

--- a/src/introspection/index.js
+++ b/src/introspection/index.js
@@ -1,0 +1,317 @@
+'use strict'
+
+const http = require('http')
+const WebSocket = require('ws')
+
+const {
+  proto: {
+    ClientCommand,
+    Runtime,
+    Configuration
+  },
+} = require('@libp2p/observer-proto')
+
+const {
+  createRuntimeMessage,
+  createVersion,
+  createDHT,
+  createConnections,
+  createState,
+  createCommandResponse,
+  updateDHT
+} = require('./create-message')
+
+const {
+  DEFAULT_CONNECTIONS,
+  DEFAULT_PEERS,
+  DEFAULT_SNAPSHOT_DURATION,
+  DEFAULT_CUTOFFTIME_SECONDS,
+} = require('./utils')
+
+const createIntrospection = ({
+  libp2p,
+  port = 8080,
+  connectionsCount = DEFAULT_CONNECTIONS,
+  peersCount = DEFAULT_PEERS,
+  duration = DEFAULT_SNAPSHOT_DURATION,
+  cutoffSeconds = DEFAULT_CUTOFFTIME_SECONDS
+}) => {
+  const version = createVersion()
+  const server = http.createServer()
+  const wss = new WebSocket.Server({ noServer: true })
+  const msgQueue = []
+
+  let connections
+  let dht
+  let runtime
+  let effectiveConfig
+  let pushEvents = false
+  let pushStates = false
+  let addDataInterval
+  let sendInterval
+
+  // TODO: Improve
+  const generateMEssages = ({
+    connectionsCount,
+    duration: durationSnapshot,
+    peersCount,
+    cutoffSeconds,
+  }) => {
+    const utcNow = Date.now()
+    const utcFrom = utcNow
+    const utcTo = utcNow + duration
+
+    if (!runtime) {
+      runtime = new Runtime([
+        'js-libp2p', // Implementation
+        '2', // Version
+        'macOS', // Platform
+        libp2p.peerId.toB58String(), // Introspecting user's own peer ID
+      ])
+      // TODO Add Runtime Events
+    }
+
+    if (!dht) {
+      dht = createDHT(libp2p._dht)
+    }
+
+    // Connections
+    const connectionsLibp2p = Array.from(libp2p.connectionManager.connections.values()).flat()
+    connections = createConnections(connectionsLibp2p)
+
+    updateDHT(dht, libp2p._dht, connections, {
+      utcFrom,
+      utcTo
+    })
+
+    if (pushStates) {
+      const statePacket = createState(
+        connections,
+        utcNow,
+        dht,
+        durationSnapshot
+      )
+      const data = Buffer.concat([version, statePacket]).toString('binary')
+      // TODO: move concat upstream
+      msgQueue.push({ ts: utcTo, type: 'state', data })
+    }
+  }
+
+  const sendQueue = (ws) => {
+    const utcNow = Date.now()
+    const queue = []
+    msgQueue.forEach((item, idx) => {
+      queue.push(msgQueue.splice(idx, 1)[0])
+    })
+
+    // console.log('send queue', queue.length)
+    queue
+      .sort((a, b) => a.ts - b.ts)
+      .forEach(item => {
+        setTimeout(() => {
+          ws.send(item.data)
+        }, Math.max(0, item.ts - utcNow))
+      })
+  }
+
+  const handleClientMessage = (ws, server, clientCommand, props) => {
+    let sendEmptyOKResponse = true
+
+    const command = clientCommand.getCommand()
+    const commandId = clientCommand.getId()
+    const commandSource = clientCommand.getSource()
+
+    if (command === ClientCommand.Command.REQUEST) {
+      if (commandSource === ClientCommand.Source.RUNTIME) {
+        console.log('Sending requested runtime')
+        sendRuntime()
+      } else {
+        console.log('Sending requested messages')
+        generateMessages(props)
+        sendQueue(ws)
+      }
+    } else if (command === ClientCommand.Command.PUSH_ENABLE) {
+      if (commandSource === ClientCommand.Source.STATE) pushStates = true
+      if (commandSource === ClientCommand.Source.EVENTS) pushEvents = true
+    } else if (command === ClientCommand.Command.PUSH_DISABLE) {
+      if (commandSource === ClientCommand.Source.STATE) pushStates = false
+      if (commandSource === ClientCommand.Source.EVENTS) pushEvents = false
+    } else if (command === ClientCommand.Command.PUSH_RESUME) {
+      clearInterval(sendInterval)
+      sendInterval = setInterval(() => {
+        sendQueue(ws)
+      }, 200)
+    } else if (command === ClientCommand.Command.PUSH_PAUSE) {
+      clearInterval(sendInterval)
+    } else if (
+      command === ClientCommand.Command.UPDATE_CONFIG ||
+      command === ClientCommand.Command.HELLO
+    ) {
+      const newConfig = clientCommand.getConfig()
+      if (newConfig) {
+        updateConfig(newConfig, commandId, ws, server)
+        sendEmptyOKResponse = false
+      } else if (command === ClientCommand.Command.HELLO) {
+        // Send default config
+        sendCommandResponse(
+          {
+            id: commandId,
+            effectiveConfig,
+          },
+          ws
+        )
+        sendEmptyOKResponse = false
+      }
+    } else {
+      sendCommandResponse(
+        {
+          id: commandId,
+          error: `Command ${command} ("${ClientCommand.Command[command]}") unrecognised by server`,
+        },
+        ws
+      )
+
+      sendEmptyOKResponse = false
+    }
+
+    if (sendEmptyOKResponse) {
+      sendCommandResponse(
+        {
+          id: commandId,
+        },
+        ws
+      )
+    }    
+  }
+
+  const updateConfig = (newConfig, commandId, ws, server) => {
+    let hasChanged = false
+
+    const newStateInterval = newConfig.getStateSnapshotIntervalMs()
+    const newRetentionPeriod = newConfig.getRetentionPeriodMs()
+
+    if (newStateInterval) {
+      clearInterval(server.generator)
+      server.generator = setInterval(() => {
+        generateMEssages({
+          connectionsCount: server.connectionsCount,
+          duration: newStateInterval
+        })
+      }, newStateInterval)
+      hasChanged = true
+      effectiveConfig.setStateSnapshotIntervalMs(newStateInterval)
+    }
+    if (newRetentionPeriod) {
+      hasChanged = true
+      effectiveConfig.setRetentionPeriodMs(newRetentionPeriod)
+    }
+    if (hasChanged) {
+      sendCommandResponse(
+        {
+          id: commandId,
+          effectiveConfig,
+        },
+        ws
+      )
+    }
+  }
+
+  const sendRuntime = (attempts = 0) => {
+    if (!runtime) {
+      // If connection requests runtime before runtime generated, wait and try again
+      if (attempts < 20) setTimeout(() => sendRuntime(attempts + 1), 500)
+      return
+    }
+
+    const runtimePacket = createRuntimeMessage({}, runtime)
+    const data = Buffer.concat([version, runtimePacket]).toString('binary')
+    // TODO: move concat upstream
+
+    msgQueue.push({ ts: Date.now(), type: 'runtime', data })
+  }
+
+  function sendCommandResponse(props, ws) {
+    const responsePacket = createCommandResponse(props)
+    // TODO: move concat upstream
+    const data = Buffer.concat([version, responsePacket]).toString('binary')
+    ws.send(data)
+  }
+
+  return {
+    start: () => {
+      if (effectiveConfig) {
+        duration = effectiveConfig.getStateSnapshotIntervalMs()
+        cutoffSeconds = effectiveConfig.getRetentionPeriodMs() / 1000
+      } else {
+        effectiveConfig = new Configuration()
+        effectiveConfig.setStateSnapshotIntervalMs(duration)
+        effectiveConfig.setRetentionPeriodMs(cutoffSeconds * 1000)
+      }
+
+      wss.connectionsCount = connectionsCount
+      clearInterval(addDataInterval)
+      clearInterval(sendInterval)
+
+      addDataInterval = setInterval(() => {
+        generateMEssages({ connectionsCount, peersCount, duration, cutoffSeconds })
+      }, duration)
+      wss.generator = addDataInterval
+
+      // handle connections
+      wss.on('connection', ws => {
+        sendInterval = setInterval(() => {
+          sendQueue(ws)
+        }, 400)
+
+        // handle incoming messages
+        ws.on('message', msg => {
+          if (!msg) {
+            return
+          }
+
+          const command = ClientCommand.deserializeBinary(msg)
+
+          try {
+            handleClientMessage(ws, wss, command)
+          } catch (err) {
+            sendCommandResponse(
+              {
+                id: command.getId(),
+                error: err.toString(),
+              },
+              ws
+            )
+            throw err
+          }
+        })
+
+        // Send runtime on connection
+        sendRuntime()
+      })
+
+      server.on('upgrade', function upgrade(request, socket, head) {
+        wss.handleUpgrade(request, socket, head, function done(ws) {
+          wss.emit('connection', ws, request)
+        })
+      })
+
+      // listen for connections
+      server.listen(port, err => {
+        if (err) {
+          console.error(err)
+        } else {
+          console.log(`Websocket server listening on ws://localhost:${port}`)
+        }
+      })
+    },
+    stop: () => {
+      // Clean up timers and server
+      clearInterval(sendInterval)
+      clearInterval(addDataInterval)
+
+      // TODO: need to handle callback
+      server.close(() => {})
+    }
+  }
+}
+module.exports = createIntrospection

--- a/src/introspection/messages/command-response.js
+++ b/src/introspection/messages/command-response.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const {
+  proto: { CommandResponse },
+} = require('@libp2p/observer-proto')
+
+function _getResult(error) {
+  if (error) return CommandResponse.Result.ERR
+  return CommandResponse.Result.OK
+}
+
+function createCommandMessage({
+  id,
+  effectiveConfig,
+  error = null,
+  result = _getResult(error),
+}) {
+  if (id === undefined)
+    throw new Error('CommandResponse needs an ID matching command ID')
+
+  const response = new CommandResponse()
+  response.setResult(result)
+  response.setError(error)
+  response.setEffectiveConfig(effectiveConfig)
+  response.setId(id)
+  return response
+}
+
+module.exports = {
+  createCommandMessage,
+}

--- a/src/introspection/messages/connections.js
+++ b/src/introspection/messages/connections.js
@@ -1,0 +1,95 @@
+'use strict'
+
+const {
+  proto: { 
+    Connection,
+    EndpointPair,
+    Stream,
+    StreamList
+  },
+} = require('@libp2p/observer-proto')
+
+const {
+  createTraffic
+} = require('./traffic')
+
+const {
+  randomLatency,
+  createTimestamp
+} = require('../utils')
+
+function createStreamTimeline({ open = 0 }) {
+  const streamTimeline = new Stream.Timeline([open])
+
+  return streamTimeline
+}
+
+function createStream (s, connection) {
+  const stream = new Stream()
+  stream.setId(Buffer.from(s.id))
+  stream.setProtocol(s.protocol)
+
+  stream.setConn(new Stream.ConnectionRef(connection))
+  stream.setTimeline(createStreamTimeline({ open: s.timeline.open }))
+  stream.setRole(0) // TODO: map Role from stat.direction
+  stream.setTraffic(createTraffic()) // TODO: fix randomness
+  stream.setLatencyNs(randomLatency()) // TODO: proper latency
+
+  return stream
+}
+
+function createConnection (connection) {
+  const c = new Connection()
+  c.setId(Buffer.from(connection.id))
+  c.setStatus(0) // TODO: map connection.stat.status
+  c.setTransportId(Buffer.from(connection.stat.multiplexer)) // TODO: infer from addresses
+  c.setPeerId(connection.remotePeer.toB58String())
+  c.setRole(0) // TODO: map Role from stat.direction
+  c.setTraffic(createTraffic()) // TODO: fix randomness
+  c.setAttribs(new Connection.Attributes([connection.stat.multiplexer, connection.stat.encryption]))
+  c.setTimeline(
+    new Connection.Timeline(mockConnectionTimeline({ open: connection.stat.timeline.open }))
+  )
+
+  c.setEndpoints(
+    new EndpointPair(
+      // TODO: UseRole
+      // role === roleList.getNum('INITIATOR')
+      //   ? [HOST_PEER_ID, peerId]
+      //   : [peerId, HOST_PEER_ID]
+      [connection.localAddr && connection.localAddr.toString(), connection.remoteAddr.toString()]
+    )
+  )
+  c.setLatencyNs(randomLatency()) // TODO: proper latency
+
+  const streamList = new StreamList()
+  connection.streams.forEach((s) => {
+    // TODO: This should really come from libp2p conn
+    const streamMetadata = connection.registry.get(s.id) || {}
+    const stream = createStream({
+      ...s,
+      ...streamMetadata
+    }, c)
+    streamList.addStreams(stream)
+  })
+
+  c.setStreams(streamList)
+
+  return c
+}
+
+function mockConnectionTimeline ({ timeline, open, close, upgraded }) {
+  const openTs = open && createTimestamp(open)
+  const closeTs = close && createTimestamp(close)
+  const upgradedTs = upgraded && createTimestamp(upgraded)
+
+  if (!timeline) return [openTs, closeTs, upgradedTs]
+
+  if (openTs) timeline.setOpenTs(openTs)
+  if (closeTs) timeline.setCloseTs(closeTs)
+  if (upgradedTs) timeline.setUpgradedTs(upgradedTs)
+}
+
+module.exports = {
+  createConnection
+}

--- a/src/introspection/messages/dht-queries.js
+++ b/src/introspection/messages/dht-queries.js
@@ -1,0 +1,27 @@
+'use strict'
+
+const { proto: { DHT } } = require('@libp2p/observer-proto')
+
+function createQueries({ dht, ...props }) {
+  const peers = dht
+    .getBucketsList()
+    .reduce((peers, bucket) => [...peers, ...bucket.getPeersList()], [])
+
+  const activeDhtPeers = peers.filter(
+    peer => peer.getStatus() === DHT.PeerInDHT.Status.ACTIVE
+  )
+  // const queryCount = randomQueryCount(activeDhtPeers.length)
+
+  // const createRandomQuery = () =>
+  //   dhtQueryDirectionList.getRandom(1) === 'INBOUND'
+  //     ? createInboundQuery(activeDhtPeers, props)
+  //     : createOutboundQuery(activeDhtPeers, props)
+
+  // return Array(queryCount)
+  //   .fill()
+  //   .map(createRandomQuery)
+}
+
+module.exports = {
+  createQueries
+}

--- a/src/introspection/messages/dht.js
+++ b/src/introspection/messages/dht.js
@@ -1,0 +1,216 @@
+'use strict'
+
+const { proto: { DHT } } = require('@libp2p/observer-proto')
+const { getKademliaDistance } = require('@libp2p/observer-data')
+
+const {
+  createTimestamp,
+  encodeBase32
+} = require('../utils')
+
+const {
+  createQueries
+} = require('./dht-queries')
+
+const DEFAULT_PEERS = 30
+
+function getActiveConnectionPeerIds (connections) {
+  const activeConnections = connections.filter(
+    conn => conn.getStatus() === statusList.getNum('ACTIVE')
+  )
+  return activeConnections.map(conn => conn.getPeerId())
+}
+
+function getCurrentBucketPeers (bucket) {
+  const inBucketStatuses = ['ACTIVE', 'MISSING']
+  return bucket
+    .getPeersList()
+    .filter(peer =>
+      inBucketStatuses.includes(dhtStatusList.getItem(peer.getStatus()))
+    )
+}
+
+function removePeerFromBucket (peer, bucket) {
+  const peerId = peer.getPeerId()
+  const peerList = bucket.getPeersList()
+  const peerIndex = peerList.findIndex(_peer => _peer.getPeerId() === peerId)
+
+  if (peerIndex < 0) {
+    throw new Error(
+      `Delete failed: bucket ${bucket.getCpl()} does not contain peer ${peerId}`
+    )
+  }
+
+  peerList.splice(peerIndex, 1)
+  bucket.setPeersList(peerList)
+  return peerList
+}
+
+function createPeerInDHT({
+  peerId,
+  bucketAge = 0,
+  status = DHT.PeerInDHT.Status.ACTIVE,
+} = {}) {
+  const pdht = new DHT.PeerInDHT()
+  pdht.setPeerId(peerId)
+  pdht.setAgeInBucket(bucketAge)
+  pdht.setStatus(status)
+  return pdht
+}
+
+function createDHT (libp2pDht) {
+  const dht = new DHT()
+
+  // Set Params
+  const params = new DHT.Params()
+  params.setK(libp2pDht.kBucketSize)
+  params.setAlpha(libp2pDht.concurrency)
+  params.setDisjointPaths(libp2pDht.disjointPaths)
+  dht.setParams(params)
+
+  dht.setProtocol(libp2pDht.protocol)
+  dht.setEnabled(true) // TODO: this should not get here if disabled
+  dht.setStartTs(createTimestamp(Date.now())) // TODO: Set proper started ts
+
+  // Start with just the "catch-all" zero-distance bucket then unfold as needed
+  const bucketZero = new DHT.Bucket()
+  bucketZero.setCpl(0)
+
+  bucketZero.setPeersList([])
+  dht.addBuckets(bucketZero)
+
+  return dht
+}
+
+function updatePeerStatus (peer, connection) {
+  // If this corresponds to a connection, mimic its status
+  if (connection) {
+    setPeerStatusByConnection(peer, connection)
+    return
+  }
+}
+
+function setPeerStatusByConnection (peer, connection) {
+  const connStatus = connection.getStatus()
+  const connActive = connStatus === 0 || connStatus === 2 // Active / Opening
+
+  const peerStatus = connActive ? DHT.PeerInDHT.Status.ACTIVE : DHT.PeerInDHT.Status.MISSING
+  peer.setStatus(peerStatus)
+}
+
+function updatePeerInDHTBucket(peer, duration) {
+  const age = peer.getAgeInBucket()
+  peer.setAgeInBucket(age + duration)
+}
+
+function updatePeerInDHT (peer, connection, duration) {
+  updatePeerStatus(peer, connection)
+  if (peer.getStatus() === DHT.PeerInDHT.Status.ACTIVE) {
+    updatePeerInDHTBucket(peer, duration)
+  }
+}
+
+function updatePeersInDHT (peers, connections, dht, duration) {
+  // const activeConnPeerIds = getActiveConnectionPeerIds(connections)
+  peers.forEach(dhtPeer => {
+    const connection = connections.find(
+      conn => conn.getPeerId() === dhtPeer.getPeerId()
+    )
+    updatePeerInDHT(dhtPeer, connection, duration)
+  })
+}
+
+function updateDHT (dht, libp2pDht, connections, { utcFrom, utcTo }) {
+  const peers = dht
+    .getBucketsList()
+    .reduce((peers, bucket) => [...peers, ...bucket.getPeersList()], [])
+  
+  const duration = utcTo - utcFrom
+  const buckets = libp2pDht.routingTable.bucketsToArray()
+
+  // Update / Remove
+  updatePeersInDHT(peers, connections, dht, duration)
+
+  // Remover peers from the bucket
+  for (let i = 0; i < buckets.length; i++) {
+    const bucketList = dht.getBucketsList()[i]
+
+    if (bucketList) {
+      const peerList = bucketList.getPeersList()
+
+      for (let j = 0; j < peerList.length; j++) {
+        if (!buckets[i].contacts.find((c) => c.peerId.toB58String() === peerList[j].getPeerId())) {
+          removePeerFromBucket(peerList[j], dht.getBucketsList()[i])
+        }
+      }
+    }
+  }
+
+  // Add new peers to bucket
+  for (let i = 0; i < buckets.length; i++) {
+    if (!dht.getBucketsList()[i]) {
+      const b = new DHT.Bucket()
+
+      b.setPeersList([])
+      dht.addBuckets(b)
+    }
+
+    const bucketList = dht.getBucketsList()[i]
+
+    // console.log('  Bucket %d (%d peers)\t\t\t', i, buckets[i].contacts.length)
+    // console.log('    Peer\t\t\t\t\t\t\tlast useful\tlast queried\tAgent Version')
+
+    for (const contact of buckets[i].contacts) {
+      const peerId = contact.peerId.toB58String()
+
+      const state = ' ' // should be '@' if peer is connected
+      // console.log('  %s %s\t%s\t%s\t%s', state, contact.peerId.toB58String(), contact.lastUsefulAt, contact.lastSuccessfulOutboundQueryAt, '-')
+
+      if (!bucketList.getPeersList().find((bl) => bl.getPeerId() === peerId)) {
+        bucketList.addPeers(createPeerInDHT({ peerId }))
+      }
+    }
+  }
+
+  // Iterate over Lookups
+  // TODO: Need to update instead of replace for endTs
+  const dhtLookups = Array.from(libp2pDht._queryManager.queries)
+  const lookups = []
+  console.log('lookups', dhtLookups.length)
+  for (let i = 0; i < dhtLookups.length; i++) {
+    const lookup = new DHT.Lookup()
+
+    console.log('lookup queries', dhtLookups[i]._run.queries.length)
+
+    lookup.setTarget(encodeBase32(dhtLookups[i].key))
+    lookup.setStartTs(dhtLookups[i]._startTime)
+
+    const queries = []
+    for (const q of dhtLookups[i]._run.queries) {
+      const query = new DHT.Query()
+
+      // console.log('query', q.peerId.toB58String(), q.startTime, q.endTime, q.closerPeers.map((c) => c.toB58String()))
+      // console.log('query', q.peerId.toB58String(), q.startTime, q.endTime, q.status)
+      query.setTarget(q.peerId.toB58String())
+      query.setStartTs(q.startTime)
+      query.setEndTs(q.endTime)
+      query.setStatus(q.status)
+      query.setDistance(q.distance)
+
+      for (const closer of q.closerPeers) {
+        query.addPeerId(closer.toB58String())
+      }
+
+      queries.push(query)
+    }
+    lookup.setQueriesList(queries)
+    lookups.push(lookup)
+  }
+
+  dht.setLookupsList(lookups)
+}
+
+module.exports = {
+  createDHT,
+  updateDHT
+}

--- a/src/introspection/messages/server-message.js
+++ b/src/introspection/messages/server-message.js
@@ -1,0 +1,56 @@
+'use strict'
+
+const {
+  proto: { ServerMessage, Version },
+} = require('@libp2p/observer-proto')
+
+function createServerMessage(message, type) {
+  const serverMessage = new ServerMessage()
+
+  serverMessage.setVersion(new Version(1))
+
+  if (type === 'runtime') {
+    serverMessage.setRuntime(message)
+  } else if (type === 'event') {
+    serverMessage.setEvent(message)
+  } else if (type === 'state') {
+    serverMessage.setState(message)
+  } else if (type === 'response') {
+    serverMessage.setResponse(message)
+  } else if (type === 'notice') {
+    serverMessage.setNotice(message)
+  } else {
+    throw new Error(`Unrecognised ServerMessage payload type "${type}"`)
+  }
+
+  return serverMessage
+}
+
+function createEventServerMessage(message) {
+  return createServerMessage(message, 'event')
+}
+
+function createRuntimeServerMessage(message) {
+  return createServerMessage(message, 'runtime')
+}
+
+function createStateServerMessage(message) {
+  return createServerMessage(message, 'state')
+}
+
+function createResponseServerMessage(message) {
+  return createServerMessage(message, 'response')
+}
+
+function createNoticeServerMessage(message) {
+  return createServerMessage(message, 'notice')
+}
+
+module.exports = {
+  createServerMessage,
+  createEventServerMessage,
+  createRuntimeServerMessage,
+  createStateServerMessage,
+  createResponseServerMessage,
+  createNoticeServerMessage,
+}

--- a/src/introspection/messages/states.js
+++ b/src/introspection/messages/states.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const {
+  proto: { State, Subsystems },
+} = require('@libp2p/observer-proto')
+
+const { createTimestamp } = require('../utils')
+// const { createTraffic, sumTraffic } = require('./traffic')
+
+function createState (connectionsList, now, dht, duration) {
+  const state = new State()
+
+  state.setInstantTs(createTimestamp(now))
+  state.setStartTs(createTimestamp(now - duration + 1))
+  state.setSnapshotDurationMs(duration)
+
+  // TODO
+  // const stateTraffic = createTraffic()
+  // state.setTraffic(stateTraffic)
+  // sumTraffic(stateTraffic, connectionsList)
+
+  const subsystems = new Subsystems()
+  subsystems.setConnectionsList(connectionsList)
+  subsystems.setDht(dht)
+  state.setSubsystems(subsystems)
+
+  return state
+}
+
+module.exports = {
+  createState
+}

--- a/src/introspection/messages/traffic.js
+++ b/src/introspection/messages/traffic.js
@@ -1,0 +1,49 @@
+'use strict'
+
+const {
+  proto: { DataGauge, Traffic },
+} = require('@libp2p/observer-proto')
+
+const {
+  randomFluctuationMultiplier,
+  randomBandwidth,
+} = require('../utils')
+
+// Store characteristics of a p2p node used for mocking
+// that don't and can't exist in the proto definition
+const mockTrafficProps = new Map()
+
+// FIX: Randomness
+
+function createTraffic() {
+  const traffic = new Traffic()
+
+  traffic.setTrafficIn(createDataGauge())
+  traffic.setTrafficOut(createDataGauge())
+
+  mockTrafficProps.set(traffic, {
+    inOutRatio: randomFluctuationMultiplier(),
+  })
+
+  return traffic
+}
+
+const mockDataGaugeProps = new Map()
+
+function createDataGauge({ bandwidth = randomBandwidth() } = {}) {
+  const dataGauge = new DataGauge()
+
+  dataGauge.setCumBytes(0)
+  dataGauge.setCumPackets(0)
+  dataGauge.setInstBw(bandwidth)
+
+  mockDataGaugeProps.set(dataGauge, {
+    previousBandwidths: [bandwidth, bandwidth, bandwidth],
+  })
+
+  return dataGauge
+}
+
+module.exports = {
+  createTraffic
+}

--- a/src/introspection/utils.js
+++ b/src/introspection/utils.js
@@ -1,0 +1,143 @@
+// https://github.com/libp2p/observer-toolkit/blob/0a6a2368bdc939c297319378b25508c464419851/packages/samples/mock/utils.js
+'use strict'
+
+const base32 = require('base32.js')
+const { fnv1a } = require('@libp2p/observer-proto')
+
+const DEFAULT_CONNECTIONS = 20
+const DEFAULT_PEERS = 30
+const DEFAULT_SNAPSHOT_DURATION = 2000 // Miliseconds
+const DEFAULT_CUTOFFTIME_SECONDS = 120
+
+const GIGABYTE_IN_BYTES = 1e9
+
+function createBufferSegment (packet) {
+  const { buffer, byteLength } = packet.serializeBinary()
+  const contentBuffer = Buffer.from(buffer)
+  const checksum = fnv1a(contentBuffer)
+
+  // Mimics the output format of go-libp2p-introspection's ws writer.
+  // First is a 4-byte LE integer that is a checksum for the following buffer
+  // Then a 4-byte LE integer stating the byte length of a state / timebar position.
+  const metaBuffer = Buffer.alloc(8)
+  metaBuffer.writeUIntLE(checksum, 0, 4)
+  metaBuffer.writeUIntLE(byteLength, 4, 4)
+
+  return Buffer.concat([metaBuffer, contentBuffer])
+}
+
+function encodeNumToBin (num) {
+  const buf = Buffer.alloc(4)
+  buf.writeUIntLE(num, 0, 4)
+  return buf
+}
+
+function decodeBinToNum (buf, offset = 0) {
+  return buf.readUIntLE(offset, 4)
+}
+
+function mapArray(size, map) {
+  // create a new array of predefined size and fill with values from map function
+  return Array.apply(null, Array(size)).map(map)
+}
+
+function createTimestamp (utcNum) {
+  if (typeof utcNum !== 'number' || Number.isNaN(utcNum)) {
+    throw new Error(
+      `Can't create timestamp from ${utcNum} (typeof ${typeof utcNum}), must be number`
+    )
+  }
+  return Math.round(utcNum) // new Timestamp([Math.round(utcNum)])
+}
+
+function getRandomiser() {
+  // Use real random numbers in real mocks, consistent ones in tests
+
+  const isTest = !!process.env.TAP
+
+  // The *tiny* but real chance of Math.random() returning actual 0 is an edge case we don't need
+  const randomAndTruthy = () => Math.random() || randomAndTruthy()
+  /* istanbul ignore if */
+  if (!isTest) return randomAndTruthy
+
+  let index = 0
+  const pseudoRandom = () => {
+    // Avoid flakey test failures with varied but consistent values
+    index = index < 39 ? index + 1 : 1
+    const decimal = (index / 4) * 0.1
+    // 0.025, 0.95, 0.075, 0.9, 0.125, 0.85...
+    return index % 2 ? decimal : 1 - decimal
+  }
+  return pseudoRandom
+}
+
+const random = getRandomiser()
+
+// Adapted from https://stackoverflow.com/questions/25582882/javascript-math-random-normal-distribution-gaussian-bell-curve
+function randomNormalDistribution ({ min, max, skew }) {
+  let u = random()
+  let v = random()
+  let num = Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v)
+  num = num / 10 + 0.5
+
+  /* istanbul ignore if : prevent unlikely cases that break the maths */
+  if (num > 1 || num < 0) return randomNormalDistribution(min, max, skew)
+
+  num = Math.pow(num, skew) // higher skew => lower values
+  return num * (max - min) + min
+}
+
+function randomBandwidth () {
+  return Math.round(
+    randomNormalDistribution({
+      min: 1,
+      max: GIGABYTE_IN_BYTES,
+      skew: 6, // Mean of around 15 mbs / second per stream
+    })
+  )
+}
+
+function randomFluctuationMultiplier () {
+  return randomNormalDistribution({
+    min: 0.5,
+    max: 2,
+    skew: 1.6, // Mean of around 1 so fluctuations don't trend up or down
+  })
+}
+
+function randomLatency () {
+  // TODO: get more info on expected values here
+  return Math.round(
+    randomNormalDistribution({
+      min: 1,
+      max: 1e9,
+      skew: 9, // Mean around 6 ms or 6e+6 ns
+    })
+  )
+}
+
+/**
+ * Encode a given Uint8Array into a base32 string.
+ * @param {Uint8Array} buf
+ * @returns {string}
+ */
+function encodeBase32 (buf) {
+  const enc = new base32.Encoder()
+  return enc.write(buf).finalize()
+}
+
+module.exports = {
+  DEFAULT_CONNECTIONS,
+  DEFAULT_PEERS,
+  DEFAULT_SNAPSHOT_DURATION,
+  DEFAULT_CUTOFFTIME_SECONDS,
+  createBufferSegment,
+  createTimestamp,
+  encodeNumToBin,
+  decodeBinToNum,
+  randomBandwidth,
+  randomFluctuationMultiplier,
+  randomLatency,
+  mapArray,
+  encodeBase32
+}

--- a/src/libp2p.js
+++ b/src/libp2p.js
@@ -93,7 +93,7 @@ const createLibp2p = async ({
       streamMuxer: [
         MPLEX
       ],
-      connEncryption,
+      connEncryption: [NOISE, SECIO],
       peerDiscovery: [
         Bootstrap
       ],
@@ -117,10 +117,20 @@ const createLibp2p = async ({
       },
       dht: {
         enabled: dht,
-        kBucketSize: 20
+        kBucketSize: 20,
+        randomWalk: {
+          enabled: false
+        }
       },
       pubsub: {
         enabled: Boolean(pubsub)
+      }
+    },
+    peerRouting: {
+      refreshManager: { // Connect to our closest peers
+        enabled: true, // Should find the closest peers.
+        interval: 120e3, // 2 mins
+        bootDelay: 10e3 // Delay for the initial query for closest peers
       }
     }
   })


### PR DESCRIPTION
This PR adds the introspection protocol for libp2p. This was done as a hack for a demo and this should be revisited. This draft PR is mostly for visibility.

The daemon is not the best place to have the introspection, specially if we want to enable libp2p users to use it when running using libp2p as a lib, such as IPFS. Libp2p should be able to have the introspection module plugged in.

Note: The `@libp2p/observer-data` and `@libp2p/observer-proto` need a `.npmrc` file to be installed.

The `@libp2p/observer-proto` was updated in TODO PR LINK and that version should be used. Unfortunately, lerna repos do not allow to install a dependency as a git branch and I cannot add it here but it is important for testing purposes.

A good example for testing the DHT widget is running:

```sh
node src/cli/bin.js --hostAddrs /ip4/0.0.0.0/tcp/55555/ws --bootstrapPeers /dnsaddr/bootstrap.libp2p.io/ipfs/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN,/dnsaddr/bootstrap.libp2p.io/ipfs/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa --bootstrap
```