### PR TITLE
update noise version

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "libp2p-gossipsub": "^0.8.0",
     "libp2p-kad-dht": "^0.21.0",
     "libp2p-mplex": "^0.10.0",
-    "libp2p-noise": "^3.0.0",
+    "libp2p-noise": "^3.1.0",
     "libp2p-tcp": "^0.15.1",
     "libp2p-websockets": "^0.15.6",
     "multiaddr": "^9.0.1",


### PR DESCRIPTION
Tried it locally and it passes interop tests with this new versions which works on node15 (we removed huge bcrypto dep)