### PR TITLE
chore: update dht

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "libp2p-bootstrap": "^0.13.0",
     "libp2p-floodsub": "^0.27.0",
     "libp2p-gossipsub": "^0.11.0",
-    "libp2p-kad-dht": "libp2p/js-libp2p-kad-dht#fix/refactor-query-logic",
+    "libp2p-kad-dht": "^0.26.0",
     "libp2p-mplex": "^0.10.0",
     "libp2p-noise": "^4.0.0",
     "libp2p-tcp": "^0.17.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "aegir": "^33.1.0",
+    "aegir": "^36.0.0",
     "delay": "^5.0.0",
     "it-pair": "^1.0.0",
     "mocha": "^9.0.1",
@@ -46,18 +46,17 @@
     "sinon": "^9.0.0"
   },
   "dependencies": {
-    "cids": "^1.1.5",
     "debug": "^4.3.1",
     "it-buffer": "^0.1.3",
     "it-handshake": "^2.0.0",
     "it-length-prefixed": "^5.0.2",
     "it-pipe": "^1.1.0",
     "it-pushable": "^1.4.0",
-    "libp2p": "^0.32.0",
+    "libp2p": "^0.33.0",
     "libp2p-bootstrap": "^0.13.0",
     "libp2p-floodsub": "^0.27.0",
     "libp2p-gossipsub": "^0.11.0",
-    "libp2p-kad-dht": "^0.23.1",
+    "libp2p-kad-dht": "libp2p/js-libp2p-kad-dht#fix/refactor-query-logic",
     "libp2p-mplex": "^0.10.0",
     "libp2p-noise": "^4.0.0",
     "libp2p-tcp": "^0.17.1",
@@ -69,7 +68,7 @@
     "protobufjs": "^6.10.2",
     "stream-to-it": "^0.2.0",
     "streaming-iterables": "^6.0.0",
-    "uint8arrays": "^2.1.0",
+    "uint8arrays": "^3.0.0",
     "yargs": "^15.0.2",
     "yargs-promise": "^1.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -78,5 +78,12 @@
     "Arve Knudsen <arve.knudsen@gmail.com>",
     "Alex Potsides <alex@achingbrain.net>",
     "Marin Petrunić <mpetrunic@users.noreply.github.com>"
-  ]
+  ],
+  "eslintConfig": {
+    "extends": "ipfs",
+    "ignorePatterns": [
+      "*.d.ts",
+      "src/profocol/index.js"
+    ]
+  }
 }

--- a/src/daemon.js
+++ b/src/daemon.js
@@ -12,8 +12,8 @@ const pipe = require('it-pipe')
 const pushable = require('it-pushable')
 const StreamHandler = require('./stream-handler')
 const { concat } = require('streaming-iterables')
-const uint8ArrayFromString = require('uint8arrays/from-string')
-const uint8ArrayToString = require('uint8arrays/to-string')
+const { fromString: uint8ArrayFromString } = require('uint8arrays/from-string')
+const { toString: uint8ArrayToString } = require('uint8arrays/to-string')
 const { passThroughUpgrader } = require('./util')
 const {
   Request,
@@ -362,7 +362,7 @@ class Daemon {
           yield OkResponse({
             dht: {
               type: DHTResponse.Type.VALUE,
-              value: value
+              value: value.val
             }
           })
         } catch (err) {


### PR DESCRIPTION
Enables DHT by default.  The tests won't pass here until libp2p is released, which needs this module to be released in order for it's tests to pass.

Depends on:

- [x] https://github.com/libp2p/js-libp2p-kad-dht/pull/237
- [ ] https://github.com/libp2p/js-libp2p/pull/1009

BREAKING CHANGE: The DHT is now enabled by default