### PR TITLE
chore: add dependabot and update engines

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "release-major": "aegir release --no-build --type major -t node"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=15.0.0"
   },
   "bugs": {
     "url": "https://github.com/libp2p/js-libp2p-daemon/issues"


### PR DESCRIPTION
Only node15+ is supported