### PR TITLE
fix: default nat hole punching to false

### DIFF
--- a/src/cli/bin.js
+++ b/src/cli/bin.js
@@ -60,6 +60,11 @@ const main = async (processArgs) => {
       type: 'boolean',
       default: false
     })
+    .option('nat', {
+      desc: 'Enables UPnP NAT hole punching',
+      type: 'boolean',
+      default: false
+    })
     .option('connMgr', {
       desc: '(Not yet supported) Enables the Connection Manager',
       type: 'boolean',


### PR DESCRIPTION
Starting stopping nodes quickly leads to tests hanging so turn it off by default.