### PR TITLE
[Fix] Use await for stream handler registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ test/test-data/go-ipfs-repo/LOG.old
 
 # while testing npm5
 package-lock.json
+
+# IDE files
+.idea/

--- a/src/daemon.js
+++ b/src/daemon.js
@@ -118,9 +118,9 @@ class Daemon {
       delete this.streamHandlers[addrString]
     }
 
-    protocols.forEach((proto) => {
+    for (const proto of protocols) {
       // Connect the client socket with the libp2p connection
-      this.libp2p.handle(proto, ({ connection, stream, protocol }) => {
+      await this.libp2p.handle(proto, ({ connection, stream, protocol }) => {
         const message = StreamInfo.encode({
           peer: connection.remotePeer.toBytes(),
           addr: connection.remoteAddr.bytes,
@@ -136,7 +136,7 @@ class Daemon {
           stream.sink
         )
       })
-    })
+    }
 
     const clientConnection = await this.tcp.dial(addr)
   }

--- a/test/daemon/streams.spec.js
+++ b/test/daemon/streams.spec.js
@@ -86,7 +86,7 @@ describe('streams', function () {
     const hello = uint8ArrayFromString('hello there')
 
     // Have the peer echo our messages back
-    libp2pPeer.handle('/echo/1.0.0', ({ stream }) => pipe(stream, stream))
+    await libp2pPeer.handle('/echo/1.0.0', ({ stream }) => pipe(stream, stream))
 
     client = new Client(daemonAddr)
     const maConn = await client.connect()


### PR DESCRIPTION
Starting from libp2p 0.36.0, libp2p.handle is async.
https://github.com/libp2p/js-libp2p/releases/tag/v0.36.0