### PR TITLE
fix: handle empty responses

### DIFF
--- a/packages/libp2p-daemon-client/src/dht.ts
+++ b/packages/libp2p-daemon-client/src/dht.ts
@@ -41,6 +41,11 @@ export class DHT {
     })
 
     const message = await sh.read()
+
+    if (message == null) {
+      throw errcode(new Error('Empty response from remote'), 'ERR_EMPTY_RESPONSE')
+    }
+
     const response = Response.decode(message)
 
     await sh.close()
@@ -67,6 +72,11 @@ export class DHT {
     })
 
     const message = await sh.read()
+
+    if (message == null) {
+      throw errcode(new Error('Empty response from remote'), 'ERR_EMPTY_RESPONSE')
+    }
+
     const response = Response.decode(message)
 
     await sh.close()
@@ -99,6 +109,11 @@ export class DHT {
     })
 
     const message = await sh.read()
+
+    if (message == null) {
+      throw errcode(new Error('Empty response from remote'), 'ERR_EMPTY_RESPONSE')
+    }
+
     const response = Response.decode(message)
 
     await sh.close()
@@ -135,6 +150,11 @@ export class DHT {
     })
 
     const message = await sh.read()
+
+    if (message == null) {
+      throw errcode(new Error('Empty response from remote'), 'ERR_EMPTY_RESPONSE')
+    }
+
     const response = Response.decode(message)
 
     await sh.close()
@@ -163,6 +183,10 @@ export class DHT {
 
     let message = await sh.read()
 
+    if (message == null) {
+      throw errcode(new Error('Empty response from remote'), 'ERR_EMPTY_RESPONSE')
+    }
+
     // stream begin message
     const response = Response.decode(message)
 
@@ -173,6 +197,11 @@ export class DHT {
 
     while (true) {
       message = await sh.read()
+
+      if (message == null) {
+        throw errcode(new Error('Empty response from remote'), 'ERR_EMPTY_RESPONSE')
+      }
+
       const response = DHTResponse.decode(message)
 
       // Stream end
@@ -214,6 +243,11 @@ export class DHT {
 
     // stream begin message
     let message = await sh.read()
+
+    if (message == null) {
+      throw errcode(new Error('Empty response from remote'), 'ERR_EMPTY_RESPONSE')
+    }
+
     const response = Response.decode(message)
 
     if (response.type !== Response.Type.OK) {
@@ -223,6 +257,11 @@ export class DHT {
 
     while (true) {
       message = await sh.read()
+
+      if (message == null) {
+        throw errcode(new Error('Empty response from remote'), 'ERR_EMPTY_RESPONSE')
+      }
+
       const response = DHTResponse.decode(message)
 
       // Stream end
@@ -265,6 +304,11 @@ export class DHT {
     })
 
     const message = await sh.read()
+
+    if (message == null) {
+      throw errcode(new Error('Empty response from remote'), 'ERR_EMPTY_RESPONSE')
+    }
+
     const response = Response.decode(message)
 
     await sh.close()

--- a/packages/libp2p-daemon-client/src/index.ts
+++ b/packages/libp2p-daemon-client/src/index.ts
@@ -114,6 +114,11 @@ class Client implements DaemonClient {
     })
 
     const message = await sh.read()
+
+    if (message == null) {
+      throw errcode(new Error('Empty response from remote'), 'ERR_EMPTY_RESPONSE')
+    }
+
     const response = Response.decode(message)
 
     if (response.type !== Response.Type.OK) {
@@ -141,6 +146,11 @@ class Client implements DaemonClient {
     })
 
     const message = await sh.read()
+
+    if (message == null) {
+      throw errcode(new Error('Empty response from remote'), 'ERR_EMPTY_RESPONSE')
+    }
+
     const response = Response.decode(message)
 
     if (response.type !== Response.Type.OK) {
@@ -173,6 +183,11 @@ class Client implements DaemonClient {
     })
 
     const message = await sh.read()
+
+    if (message == null) {
+      throw errcode(new Error('Empty response from remote'), 'ERR_EMPTY_RESPONSE')
+    }
+
     const response = Response.decode(message)
 
     if (response.type !== Response.Type.OK) {
@@ -243,6 +258,11 @@ class Client implements DaemonClient {
     })
 
     const message = await sh.read()
+
+    if (message == null) {
+      throw errcode(new Error('Empty response from remote'), 'ERR_EMPTY_RESPONSE')
+    }
+
     const response = Response.decode(message)
 
     await sh.close()

--- a/packages/libp2p-daemon-client/src/pubsub.ts
+++ b/packages/libp2p-daemon-client/src/pubsub.ts
@@ -28,6 +28,11 @@ export class Pubsub {
     })
 
     const message = await sh.read()
+
+    if (message == null) {
+      throw errcode(new Error('Empty response from remote'), 'ERR_EMPTY_RESPONSE')
+    }
+
     const response = Response.decode(message)
 
     await sh.close()
@@ -65,6 +70,11 @@ export class Pubsub {
     })
 
     const message = await sh.read()
+
+    if (message == null) {
+      throw errcode(new Error('Empty response from remote'), 'ERR_EMPTY_RESPONSE')
+    }
+
     const response = Response.decode(message)
 
     await sh.close()
@@ -91,6 +101,11 @@ export class Pubsub {
     })
 
     let message = await sh.read()
+
+    if (message == null) {
+      throw errcode(new Error('Empty response from remote'), 'ERR_EMPTY_RESPONSE')
+    }
+
     const response = Response.decode(message)
 
     if (response.type !== Response.Type.OK) {
@@ -100,6 +115,11 @@ export class Pubsub {
     // stream messages
     while (true) {
       message = await sh.read()
+
+      if (message == null) {
+        throw errcode(new Error('Empty response from remote'), 'ERR_EMPTY_RESPONSE')
+      }
+
       yield PSMessage.decode(message)
     }
   }

--- a/packages/libp2p-daemon-protocol/src/stream-handler.ts
+++ b/packages/libp2p-daemon-protocol/src/stream-handler.ts
@@ -30,7 +30,7 @@ export class StreamHandler {
   /**
    * Read and decode message
    */
-  async read () {
+  async read (): Promise<Uint8Array | undefined> {
     // @ts-expect-error decoder is really a generator
     const msg = await this.decoder.next()
     if (msg.value != null) {
@@ -52,7 +52,7 @@ export class StreamHandler {
   /**
    * Return the handshake rest stream and invalidate handler
    */
-  rest () {
+  rest (): Duplex<Uint8ArrayList, Uint8Array> {
     this.shake.rest()
     return this.shake.stream
   }
@@ -60,7 +60,7 @@ export class StreamHandler {
   /**
    * Close the stream
    */
-  async close () {
+  async close (): Promise<void> {
     log('closing the stream')
     await this.rest().sink([])
   }


### PR DESCRIPTION
Sometimes nothing is received from the remote so throw an appropriate error in that case.