### PR TITLE
feat: add get subscribers for pubsub topics

### DIFF
--- a/packages/libp2p-daemon-client/src/index.ts
+++ b/packages/libp2p-daemon-client/src/index.ts
@@ -295,6 +295,7 @@ export interface PubSubClient {
   publish: (topic: string, data: Uint8Array) => Promise<void>
   subscribe: (topic: string) => AsyncIterable<PSMessage>
   getTopics: () => Promise<string[]>
+  getSubscribers: (topic: string) => Promise<PeerId[]>
 }
 
 export interface DaemonClient {

--- a/packages/libp2p-daemon-server/src/index.ts
+++ b/packages/libp2p-daemon-server/src/index.ts
@@ -297,6 +297,13 @@ export class Server implements Libp2pServer {
 
           yield * this.pubsubOperations.publish(request.topic, request.data)
           return
+        case PSRequest.Type.LIST_PEERS:
+          if (request.topic == null) {
+            throw new Error('Invalid request')
+          }
+
+          yield * this.pubsubOperations.listPeers(request.topic)
+          return
         default:
           throw new Error('ERR_INVALID_REQUEST_TYPE')
       }

--- a/packages/libp2p-daemon-server/src/pubsub.ts
+++ b/packages/libp2p-daemon-server/src/pubsub.ts
@@ -84,4 +84,18 @@ export class PubSubOperations {
       yield ErrorResponse(err)
     }
   }
+
+  async * listPeers (topic: string): AsyncGenerator<Uint8Array, void, undefined> {
+    try {
+      yield OkResponse({
+        pubsub: {
+          topics: [topic],
+          peerIDs: this.pubsub.getSubscribers(topic).map(peer => peer.toBytes())
+        }
+      })
+    } catch (err: any) {
+      log.error(err)
+      yield ErrorResponse(err)
+    }
+  }
 }


### PR DESCRIPTION
With this implemented we can remove some of the arbitrary delays in the interop tests, instead we can wait until we see the remote node in the topic peer list.