### PR TITLE
fix!: update pubsub subscribe method to return subscription

### DIFF
--- a/packages/libp2p-daemon-client/src/index.ts
+++ b/packages/libp2p-daemon-client/src/index.ts
@@ -54,6 +54,9 @@ class Client implements DaemonClient {
   async send (request: Request): Promise<StreamHandler> {
     const maConn = await this.connectDaemon()
 
+    const subtype = request.pubsub?.type ?? request.dht?.type ?? request.peerStore?.type ?? ''
+    log('send', request.type, subtype)
+
     const streamHandler = new StreamHandler({ stream: maConn })
     streamHandler.write(Request.encode(request))
     return streamHandler
@@ -291,9 +294,14 @@ export interface DHTClient {
   getClosestPeers: (key: Uint8Array) => AsyncIterable<PeerInfo>
 }
 
+export interface Subscription {
+  messages: () => AsyncIterable<PSMessage>
+  cancel: () => Promise<void>
+}
+
 export interface PubSubClient {
   publish: (topic: string, data: Uint8Array) => Promise<void>
-  subscribe: (topic: string) => AsyncIterable<PSMessage>
+  subscribe: (topic: string) => Promise<Subscription>
   getTopics: () => Promise<string[]>
   getSubscribers: (topic: string) => Promise<PeerId[]>
 }


### PR DESCRIPTION
Subscribing to pubsub topics is a two step process - first we subscribe, then we receive messages.

We may subscribe and not receive messages, so change the return type to reflect that.

It now returns a promise, after which is resolved the node is subscribed, and the response has a `messages` method that can be used to iterate over any received messages, and a `cancel` method that will cancel the subscription.

BREAKING CHANGE: the return type of `client.pubsub.subscribe` has changed