### PR TITLE
fix: use "limited" instead of "transient"

### DIFF
--- a/packages/libp2p-daemon-server/src/index.ts
+++ b/packages/libp2p-daemon-server/src/index.ts
@@ -114,7 +114,9 @@ export class Server implements Libp2pServer {
 
     log('openStream - open stream for protocol %s', proto)
     const stream = await connection.newStream(proto, {
-      runOnTransientConnection: true
+      runOnTransientConnection: true,
+      // @ts-expect-error this has not been released yet
+      runOnLimitedConnection: true
     })
 
     return {
@@ -192,7 +194,9 @@ export class Server implements Libp2pServer {
           }
         })
     }, {
-      runOnTransientConnection: true
+      runOnTransientConnection: true,
+      // @ts-expect-error this has not been released yet
+      runOnLimitedConnection: true
     })
   }
 


### PR DESCRIPTION
In the upcoming libp2p@2.x release "transient" will change to "limited" so use the newer terminology.

Temporarily uses both config keys to ensure backwards compatibility.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works