### PR TITLE
fix: use upgrader to get incoming connections

### DIFF
--- a/packages/libp2p-daemon-protocol/src/upgrader.ts
+++ b/packages/libp2p-daemon-protocol/src/upgrader.ts
@@ -1,8 +1,24 @@
-import type { Upgrader } from '@libp2p/interface'
+import type { Connection, MultiaddrConnection, Upgrader } from '@libp2p/interface'
 
-export const passThroughUpgrader: Upgrader = {
-  // @ts-expect-error should return a connection
-  upgradeInbound: async maConn => maConn,
-  // @ts-expect-error should return a connection
-  upgradeOutbound: async maConn => maConn
+interface OnConnection {
+  (conn: MultiaddrConnection): void
+}
+
+export class PassThroughUpgrader implements Upgrader {
+  private readonly onConnection?: OnConnection
+
+  constructor (handler?: OnConnection) {
+    this.onConnection = handler
+  }
+
+  async upgradeInbound (maConn: MultiaddrConnection): Promise<Connection> {
+    this.onConnection?.(maConn)
+    // @ts-expect-error should return a connection
+    return maConn
+  }
+
+  async upgradeOutbound (maConn: MultiaddrConnection): Promise<Connection> {
+    // @ts-expect-error should return a connection
+    return maConn
+  }
 }

--- a/packages/libp2p-daemon-server/src/index.ts
+++ b/packages/libp2p-daemon-server/src/index.ts
@@ -8,7 +8,7 @@ import {
   PSRequest,
   StreamInfo
 } from '@libp2p/daemon-protocol'
-import { passThroughUpgrader } from '@libp2p/daemon-protocol/upgrader'
+import { PassThroughUpgrader } from '@libp2p/daemon-protocol/upgrader'
 import { defaultLogger, logger } from '@libp2p/logger'
 import { peerIdFromMultihash } from '@libp2p/peer-id'
 import { tcp } from '@libp2p/tcp'
@@ -63,9 +63,7 @@ export class Server implements Libp2pServer {
       logger: defaultLogger()
     })
     this.listener = this.tcp.createListener({
-      // @ts-expect-error connection may actually be a maconn?
-      handler: this.handleConnection.bind(this),
-      upgrader: passThroughUpgrader
+      upgrader: new PassThroughUpgrader(this.handleConnection.bind(this))
     })
     this._onExit = this._onExit.bind(this)
 
@@ -150,7 +148,7 @@ export class Server implements Libp2pServer {
           // @ts-expect-error because we use a passthrough upgrader,
           // this is actually a MultiaddrConnection and not a Connection
           conn = await this.tcp.dial(addr, {
-            upgrader: passThroughUpgrader
+            upgrader: new PassThroughUpgrader()
           })
 
           const message = StreamInfo.encode({


### PR DESCRIPTION
Refactors to use the upgrader instead of the handler similar to libp2p.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works